### PR TITLE
Add method `connections(&self) -> usize`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,4 +105,13 @@ impl Server {
     pub async fn send_heartbeat(&mut self) {
         self.send_to_clients(":\n\n").await
     }
+
+    /// Count the number of currently held connections. Note that this may be an
+    /// over-estimate of the number of currently connected clients, as some
+    /// clients may have disconnected since the last `send_to_clients` or
+    /// `send_heartbeat` (both of which prune the list of connections to those
+    /// which still have a connected client).
+    pub fn connections(&self) -> usize {
+        self.clients.len()
+    }
 }


### PR DESCRIPTION
This PR adds a single method to count the number of connections currently held by the server. As described in the method docs:

> Count the number of currently held connections. Note that this may be an over-estimate of the number of currently connected clients, as some clients may have disconnected since the last `send_to_clients` or `send_heartbeat` (both of which prune the list of connections to those which still have a connected client).

This method is useful for situations where there are a dynamic number of `Server`s, and we wish to periodically prune those which don't have any active connections.

This change is a non-breaking change as it only adds a new method.

A possible breaking change which may be worth considering: should `send_to_clients`, `send_heartbeat`, and `add_client` return `self.connections(): usize` instead of `()`? It's almost always the case in scenarios I can think of that we'd only want to check for the number of connections after performing one of these actions, and the runtime cost would be very small. What are your thoughts?